### PR TITLE
Fix incorrect sigmoid implementation and add test script

### DIFF
--- a/Machine Learning/basics/logistic_regression.py
+++ b/Machine Learning/basics/logistic_regression.py
@@ -36,4 +36,4 @@ class LogisticRegressor:
         return np.array(y_predicted_cls)
 
     def _sigmoid(self, x):
-        return 1 / (1 + np.exp(x))
+        return 1 / (1 + np.exp(-x))

--- a/Machine Learning/basics/testing_logistic_regression.py
+++ b/Machine Learning/basics/testing_logistic_regression.py
@@ -1,0 +1,18 @@
+import numpy as np
+from logistic_regression import LogisticRegressor
+
+# Dataset for testing 
+X = np.array([[1], [2], [3], [4]])
+y = np.array([0, 0, 1, 1])
+
+model = LogisticRegressor(learning_rate=0.01, n_iterations=1000)
+model.fit(X,y)
+
+preds = model.predict(X)
+print(f"Predictions: {preds}")
+
+errors = (y + preds) == 1
+num_errors = np.sum(errors)
+accuracy = (1 - (num_errors/len(y))) * 100
+
+print(f"Accuracy of the prediction: {accuracy}%")


### PR DESCRIPTION
Before my changes:
The "_sigmoid" function in logistic_regression.py was used wrong mathematical formula: it used "exp(x)" instead of "exp(-x)" and it produced values greater than 1 and broke the logistic regression logic.

After my changes:
1.  I corrected the formula inside the "_sigmoid" function to 1 / (1 + exp(-x)).
2.  I added `testing_logistic_regression.py` with a small test dataset to validate the fix.
3. I verified that predictions now fall correctly in {0,1} and accuracy computes properly.


Closes #96.

