### PR TITLE
Fix bug in GCD code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 ideas.txt
+.vscode

--- a/Algorithms/Basics/gcd/code.cpp
+++ b/Algorithms/Basics/gcd/code.cpp
@@ -7,7 +7,7 @@ int gcd(int a, int b) {
         if (a > b)
             a = a - b;
         else
-            b = a - b; 
+            b = b - a; 
     }
     return a;
 }


### PR DESCRIPTION
closes #65 

- Added .vscode in .gitignore, as it was not there at the start
- There was a subtle bug in GCD code where b was supposed to be a in one line and vice versa. I have fixed that bug and checked the code locally that it ran fine.